### PR TITLE
Refactor serial command handling, add HTTP handlers, and expand parser tests

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,6 +33,9 @@ const (
 	defaultBaudRate    = 115200
 	defaultDataBits    = 8
 	readHeaderTimeout  = 5 * time.Second
+	startCommand       = "STA\r\n"
+	stopCommand        = "STP\r\n"
+	commandHeaderLines = 2
 )
 
 func parser(data string) (Status, error) {
@@ -46,21 +49,12 @@ func parser(data string) (Status, error) {
 	}
 
 	for _, split := range splits {
-		var err error
 		keyValue := strings.Split(split, "=")
 		if len(keyValue) != keyValueLength {
 			continue
 		}
 
-		switch keyValue[0] {
-		case "CO2":
-			result.co2, err = strconv.ParseFloat(keyValue[1], 64)
-		case "HUM":
-			result.hum, err = strconv.ParseFloat(keyValue[1], 64)
-		case "TMP":
-			result.temp, err = strconv.ParseFloat(keyValue[1], 64)
-		}
-		if err != nil {
+		if err := parseKeyValue(keyValue[0], keyValue[1], &result); err != nil {
 			logger.Println(err, split)
 			return Status{}, ErrInvalidFormat
 		}
@@ -69,10 +63,34 @@ func parser(data string) (Status, error) {
 	return result, nil
 }
 
-func recordMetrics() error {
-	port, err := serial.Open(*deviceName, &serial.Mode{})
+func parseKeyValue(key, value string, result *Status) error {
+	switch key {
+	case "CO2":
+		parsed, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return err
+		}
+		result.co2 = parsed
+	case "HUM":
+		parsed, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return err
+		}
+		result.hum = parsed
+	case "TMP":
+		parsed, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return err
+		}
+		result.temp = parsed
+	}
+	return nil
+}
+
+func openSerialPort(device string) (serial.Port, error) {
+	port, err := serial.Open(device, &serial.Mode{})
 	if err != nil {
-		return fmt.Errorf("open serial port: %w", err)
+		return nil, fmt.Errorf("open serial port: %w", err)
 	}
 	mode := &serial.Mode{
 		BaudRate: defaultBaudRate,
@@ -81,14 +99,29 @@ func recordMetrics() error {
 		StopBits: serial.OneStopBit,
 	}
 	if err := port.SetMode(mode); err != nil {
-		return fmt.Errorf("set mode: %w", err)
+		return nil, fmt.Errorf("set mode: %w", err)
 	}
-	if _, err := port.Write([]byte("STA\r\n")); err != nil {
-		return fmt.Errorf("write start command: %w", err)
+	return port, nil
+}
+
+func writeCommand(port serial.Port, command string) error {
+	if _, err := port.Write([]byte(command)); err != nil {
+		return fmt.Errorf("write command %q: %w", strings.TrimSpace(command), err)
+	}
+	return nil
+}
+
+func recordMetrics() error {
+	port, err := openSerialPort(*deviceName)
+	if err != nil {
+		return err
+	}
+	if err := writeCommand(port, startCommand); err != nil {
+		return err
 	}
 
 	defer func() {
-		if _, err = port.Write([]byte("STP\r\n")); err != nil {
+		if err := writeCommand(port, stopCommand); err != nil {
 			logger.Println("write stop command:", err)
 		}
 		if err := port.Close(); err != nil {
@@ -98,8 +131,9 @@ func recordMetrics() error {
 
 	scanner := bufio.NewScanner(port)
 	// skip first 2 lines for command response
-	scanner.Scan()
-	scanner.Scan()
+	for i := 0; i < commandHeaderLines; i++ {
+		scanner.Scan()
+	}
 
 	for scanner.Scan() {
 		stat, err := parser(scanner.Text())
@@ -134,20 +168,26 @@ var (
 	})
 )
 
+func metricsHandler() http.Handler {
+	return promhttp.Handler()
+}
+
+func indexHandler(w http.ResponseWriter, request *http.Request) {
+	w.Header().Set("Content-Type", "text/html")
+	// language=HTML
+	_, err := w.Write([]byte(`<html><head><title>UD-CO2S Exporter</title></head><body>` +
+		`<a href="/metrics">metrics</a></body></html>`))
+	if err != nil {
+		return
+	}
+}
+
 func run() error {
 	e := errgroup.Group{}
 	e.Go(recordMetrics)
 
-	http.Handle("/metrics", promhttp.Handler())
-	http.HandleFunc("/", func(w http.ResponseWriter, request *http.Request) {
-		w.Header().Set("Content-Type", "text/html")
-		// language=HTML
-		_, err := w.Write([]byte(`<html><head><title>UD-CO2S Exporter</title></head><body>` +
-			`<a href="/metrics">metrics</a></body></html>`))
-		if err != nil {
-			return
-		}
-	})
+	http.Handle("/metrics", metricsHandler())
+	http.HandleFunc("/", indexHandler)
 	e.Go(func() error {
 		server := &http.Server{
 			Addr:              *addr,

--- a/main_test.go
+++ b/main_test.go
@@ -7,56 +7,88 @@ import (
 
 func TestParser(t *testing.T) {
 	tests := []struct {
-		in  string
-		out Status
-		err error
+		name string
+		in   string
+		out  Status
+		err  error
 	}{
 		{
-			"CO2=1012,HUM=35.2,TMP=29.6",
-			Status{
+			name: "valid",
+			in:   "CO2=1012,HUM=35.2,TMP=29.6",
+			out: Status{
 				co2:  1012,
 				hum:  35.2,
 				temp: 29.6,
 			},
-			nil,
+			err: nil,
 		},
 		{
-			"CO2=1012,HUM=35.2,TMP=29.6\r\n",
-			Status{
+			name: "valid with line ending",
+			in:   "CO2=1012,HUM=35.2,TMP=29.6\r\n",
+			out: Status{
 				co2:  1012,
 				hum:  35.2,
 				temp: 29.6,
 			},
-			nil,
+			err: nil,
 		},
 		{
-			"CO2=90,HUM=1.0,TMP=1\r\n",
-			Status{
+			name: "valid with integer temperature",
+			in:   "CO2=90,HUM=1.0,TMP=1\r\n",
+			out: Status{
 				co2:  90,
 				hum:  1.0,
 				temp: 1,
 			},
-			nil,
+			err: nil,
 		},
 		{
-			"CO2=90",
-			Status{},
-			ErrInvalidFormat,
+			name: "invalid field count",
+			in:   "CO2=90",
+			out:  Status{},
+			err:  ErrInvalidFormat,
 		},
 		{
-			"",
-			Status{},
-			ErrInvalidFormat,
+			name: "empty input",
+			in:   "",
+			out:  Status{},
+			err:  ErrInvalidFormat,
+		},
+		{
+			name: "invalid value",
+			in:   "CO2=1012,HUM=bad,TMP=29.6",
+			out:  Status{},
+			err:  ErrInvalidFormat,
+		},
+		{
+			name: "unknown key is ignored",
+			in:   "CO2=1012,HUM=35.2,XXX=1",
+			out: Status{
+				co2: 1012,
+				hum: 35.2,
+			},
+			err: nil,
+		},
+		{
+			name: "missing equals is ignored",
+			in:   "CO2=1012,HUM=35.2,TMP",
+			out: Status{
+				co2: 1012,
+				hum: 35.2,
+			},
+			err: nil,
 		},
 	}
 
 	for _, tt := range tests {
-		stat, err := parser(tt.in)
-		if !errors.Is(err, tt.err) {
-			t.Errorf("expect error got %v, want %v", stat, tt.out)
-		}
-		if stat != tt.out {
-			t.Errorf("got %v, want %v", stat, tt.out)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			stat, err := parser(tt.in)
+			if !errors.Is(err, tt.err) {
+				t.Fatalf("expect error got %v, want %v", stat, tt.out)
+			}
+			if stat != tt.out {
+				t.Fatalf("got %v, want %v", stat, tt.out)
+			}
+		})
 	}
 }


### PR DESCRIPTION
### Motivation
- Reduce duplication and clarify serial-command flow by extracting helpers and named constants for commands and header length.
- Make the parsing logic more testable and robust by isolating key/value parsing into a dedicated function.
- Separate HTTP handler wiring from `run` to improve readability and make the HTTP endpoints easier to adjust.
- Increase unit-test coverage for the `parser` to validate edge cases and input robustness.

### Description
- Introduce constants `startCommand`, `stopCommand`, and `commandHeaderLines` and use them where commands/header skipping are needed in `main.go`.
- Extract `parseKeyValue`, `openSerialPort`, and `writeCommand` helper functions and update `recordMetrics` to use these helpers and a loop-driven header-skip instead of inline logic.
- Add `metricsHandler` and `indexHandler` functions and register them in `run` instead of inlining the handler code.
- Expand `main_test.go` with named subtests and additional cases (invalid values, unknown keys ignored, missing equals ignored) to exercise `parser` behavior.

### Testing
- Ran `go test ./...` and all tests passed.
- Updated unit tests (`main_test.go`) and executed them as part of the test run which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e6838c13c83248a46132cc1855b1d)